### PR TITLE
Return to saved year

### DIFF
--- a/ICB_Place_Based_Tool.py
+++ b/ICB_Place_Based_Tool.py
@@ -71,7 +71,7 @@ if len(st.session_state) < 1:
         ],
         "icb": "NHS West Yorkshire ICB"
     }
-    st.session_state["year"] = "2023_24"
+    st.session_state["year"] = "2023_2024"
 if "places" not in st.session_state:
     st.session_state.places = ["Default Place"]
 # Functions & Calls
@@ -349,14 +349,14 @@ if advanced_options:
             st.session_state.places = d.get("places", ["Default Place"])
             for place in st.session_state.places:
                 st.session_state[place] = d.get(place, {})
-            st.session_state["year"] = d.get("year", "2023_24")
+            st.session_state["year"] = d.get("year", "2023_2024")
             my_bar = st.sidebar.progress(0)
             for percent_complete in range(100):
                 time.sleep(0.01)
                 my_bar.progress(percent_complete + 1)
             my_bar.empty()
 
-            st.nerun()
+            st.rerun()
     
 
 see_session_data = st.sidebar.checkbox("Show Session Data")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ streamlit_folium~=0.4.0
 regex~=2021.11.10
 altair==4.0
 numpy==1.26.4
+xslxwriter==3.2.0
 pytest


### PR DESCRIPTION
Changes:

- Added line below select time period and extra info box to make year super clear.
- Added year into the session state, whatever the year was when the user saved the most recent place to the session state, it will now default to that when uploaded.
- It will not jump between years as a user jumps between saved places, regardless of the year it was when they clicked save. 