### PR TITLE
Fixed error in main page title

### DIFF
--- a/ICB_Place_Based_Tool.py
+++ b/ICB_Place_Based_Tool.py
@@ -149,7 +149,7 @@ svg = """
 """
 render_svg(svg)
 
-st.title("ICB Place Based Allocation Tool " + config['allocations_year'] + " FAQs")
+st.title("ICB Place Based Allocation Tool " + config['allocations_year'])
 
 #Code below uses the date of last modification for the file to create a last updated date.
 script_path = Path(__file__)


### PR DESCRIPTION
Main title page included "FAQ", likely from copying the line from the FAQ page.  Removed now.