### PR TITLE
Sl 20250304 zerooutputs

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -44,7 +44,7 @@ def get_data(path):
 
         }
     )
-    df = df.fillna(1).replace(0, 1)
+    df = df.fillna(0)
     df["practice_display"] = df["GP Practice code"] + ": " + df["GP Practice name"]
     return df
 


### PR DESCRIPTION
Tool originally imported zeroes as 1s, likely to avoid divide-by-zero errors.

Changed to import zeroes as is, as divide-by-zero errors not possible in current tool.