### PR TITLE
Last updated date fixed

### DIFF
--- a/ICB_Place_Based_Tool.py
+++ b/ICB_Place_Based_Tool.py
@@ -37,6 +37,7 @@ import pandas as pd
 from streamlit_folium import folium_static
 import folium
 import toml
+import requests
 
 
 # Page setup
@@ -161,12 +162,9 @@ render_svg(svg)
 # Page title, calling the defined year from the config file
 st.title("ICB Place Based Allocation Tool " + config['allocations_year'])
 
-# Last updated date line; uses the date of last modification for the file to create a last updated date
-script_path = Path(__file__)
-last_modified_time = script_path.stat().st_mtime
-last_modified_date = time.localtime(last_modified_time)
-formatted_date = time.strftime('%d %B %Y', last_modified_date)
-st.write(f"Last updated: {formatted_date}")
+# Uses the get_latest_commit_date function from utils to fetch the most recent commit date based on details from the config file and displays it on the page
+last_commit_date = utils.get_latest_commit_date(config['owner'], config['repo'], config['branch'])
+st.write(f"Last updated: {last_commit_date}")
 
 
 # SIDEBAR Prologue

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,7 @@
 #Sets the allocation year that is used to populate dashboard titles
 allocations_year = '2025/26'
+
+#Repo details used for fetching latest commit date
+owner = "nhsengland"
+repo = "ICB_Allocation_Tool_update"
+branch = "main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy
 pytest
 xlsxwriter
 pyarrow
+requests

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,8 @@ from st_aggrid import AgGrid, GridOptionsBuilder
 import pandas as pd
 from decimal import Decimal, ROUND_HALF_UP
 import os
+import requests
+from datetime import datetime
 
 
 # Load data and cache
@@ -308,3 +310,29 @@ def set_sidebar_width(min_width=300, max_width=300):
         """,
         unsafe_allow_html=True
     )
+
+#Fetch latest date of commit to main GitHub repo main branch and format it for display in tool
+def get_latest_commit_date(owner, repo, branch):
+    """
+    Uses the requests library to pull the latest commit date for the repo from GitHub API.
+
+    Parameters:
+    owner (string): The username of the owner of the repo
+    repo (string): The repo to fetch the latest commit date from
+    branch (string): The branch to fetch the latest commit date from
+
+    Note: In the tool, the parameters are populated from the config file, to make future updates easier.
+
+    Returns:
+    formatted_date (string): The date of the last commit to the specified repo and branch in the format "DD month YYYY"
+    """
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{branch}"
+    response = requests.get(url)
+    if response.status_code == 200:
+        commit_data = response.json()
+        date_str = commit_data["commit"]["committer"]["date"]
+        date_obj = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%SZ")
+        formatted_date = date_obj.strftime("%d %B %Y")
+        return formatted_date
+    else:
+        return "Unknown"


### PR DESCRIPTION
Previously pulled last updated date from the file, but due to issues with the way streamlit caches files, this was constantly showing the current date.

Changed to use the requests library to pull from GitHub API to find the last date of a commit to the main branch of the repo.